### PR TITLE
Merge additive items from upstream PR #35 (namespace fix + class attributes)

### DIFF
--- a/src/XMLDoc2Markdown/Program.cs
+++ b/src/XMLDoc2Markdown/Program.cs
@@ -172,7 +172,7 @@ internal class Program
             IEnumerable<IGrouping<string, Type>> typesByNamespace = types.GroupBy(type => type.Namespace).OrderBy(g => g.Key);
             foreach (IGrouping<string, Type> namespaceTypes in typesByNamespace)
             {
-                indexPage.AppendHeader($"Namespace {namespaceTypes.Key}", 2);
+                indexPage.AppendHeader($"Namespace {namespaceTypes.Key ?? "No namespace"}", 2);
 
                 foreach (Type type in namespaceTypes.OrderBy(x => x.Name))
                 {

--- a/src/XMLDoc2Markdown/TypeDocumentation.cs
+++ b/src/XMLDoc2Markdown/TypeDocumentation.cs
@@ -43,7 +43,10 @@ internal partial class TypeDocumentation
 
         this._document.AppendHeader(this._type.GetDisplayName().FormatChevrons(), 1);
 
-        this._document.AppendParagraph($"Namespace: {this._type.Namespace}");
+        if (this._type.Namespace != null)
+        {
+            this._document.AppendParagraph($"Namespace: {this._type.Namespace}");
+        }
 
         XElement typeDocElement = this._documentation.GetMember(this._type);
 
@@ -56,7 +59,7 @@ internal partial class TypeDocumentation
         this.WriteMemberInfoSummary(typeDocElement);
         this.WriteMemberInfoSignature(this._type);
         this.WriteTypeParameters(this._type, typeDocElement);
-        this.WriteInheritanceAndImplements();
+        this.WriteInheritanceAndImplementsAndAttributes();
         this.WriteMemberInfoRemarks(typeDocElement);
 
         if (this._type.IsEnum)
@@ -117,7 +120,7 @@ internal partial class TypeDocumentation
         }
     }
 
-    private void WriteInheritanceAndImplements()
+    private void WriteInheritanceAndImplementsAndAttributes()
     {
         List<string> lines = new();
 
@@ -141,6 +144,17 @@ internal partial class TypeDocumentation
                     noExtension: this._options.GitHubPages || this._options.GitlabWiki,
                     noPrefix: this._options.GitlabWiki));
             lines.Add($"Implements {string.Join(", ", implements)}");
+        }
+
+        IEnumerable<Attribute> attributes = this._type.GetCustomAttributes();
+        if (attributes.Any())
+        {
+            IEnumerable<MarkdownInlineElement> links = attributes
+                .Select(a => a.GetType().GetDocsLink(
+                    this._assembly,
+                    noExtension: this._options.GitHubPages || this._options.GitlabWiki,
+                    noPrefix: this._options.GitlabWiki));
+            lines.Add($"Attributes {string.Join(", ", links)}");
         }
 
         if (lines.Any())

--- a/src/XMLDoc2Markdown/Utils/MemberInfoExtensions.cs
+++ b/src/XMLDoc2Markdown/Utils/MemberInfoExtensions.cs
@@ -40,7 +40,7 @@ internal static class MemberInfoExtensions
         switch (memberInfo)
         {
             case Type type:
-                return Regex.Replace(type.FullName, @"\[.*\]", string.Empty).Replace('+', '.');
+                return Regex.Replace(type.FullName ?? type.Name, @"\[.*\]", string.Empty).Replace('+', '.');
 
             case PropertyInfo _:
             case FieldInfo _:


### PR DESCRIPTION
## Summary

Selectively merges two non-breaking improvements from [charlesdevandiere/xmldoc2md#35](https://github.com/charlesdevandiere/xmldoc2md/pull/35) (v5.0.0), tracking [issue #5](https://github.com/nefarius/xmldoc2md/issues/5).

- **Namespace-less type fix** ([upstream #28](https://github.com/charlesdevandiere/xmldoc2md/issues/28)): types declared in the global namespace (no explicit `Namespace`) previously caused null-ref errors or blank `## Namespace ` headings in `index.md`. Now they are grouped under `## Namespace No namespace` and `GetIdentifier` falls back to `type.Name` when `FullName` is null.
- **Class-level attributes documentation**: the type page now emits an `Attributes ...` line (with MS Docs or internal links) next to the existing `Inheritance` and `Implements` lines. `WriteInheritanceAndImplements` has been renamed to `WriteInheritanceAndImplementsAndAttributes`.

## What was intentionally skipped

The following breaking/large items from upstream PR #35 were **not** merged to preserve the fork's custom CLI flags and template system:

- `--structure [flat|tree]` — would touch all URL-building extension methods
- `--member-accessibility-level` — would drop `--private-members`, `--onlyinternal-members`, `--excludeinternal`
- `System.CommandLine` migration — would rewrite `Program.cs` and lose template/back-button options
- `net8.0` target downgrade — fork is already on `net9.0`

## Test plan

- [x] `dotnet build` succeeds with 0 errors, 0 warnings
- [x] Sample docs regenerated: 8 types, 0 failures
- [x] `MyObsoleteClass` page now shows `Attributes [ObsoleteAttribute](...)` line
- [x] Index page namespaces render correctly for all namespaced types

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of types without namespaces in generated documentation
  * Enhanced robustness for edge cases in type name resolution

* **New Features**
  * Type documentation now displays custom attributes information

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nefarius/xmldoc2md/pull/6?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->